### PR TITLE
Remove incomplete Quick Start section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,6 @@ To install MongoFlow, add the following package to your project:
 dotnet add package MongoFlow
 ```
 
-## Quick Start
-
-```csharp
-TODO
-```
-
 ## Contributing
 
 1. Fork the repository


### PR DESCRIPTION
The Quick Start section had a placeholder with "TODO" which might confuse readers. This incomplete section has been removed to maintain the document's clarity and professionalism.