### PR TITLE
Update release workflow to use workflow_dispatch

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,7 +1,5 @@
 name-template: 'v$RESOLVED_VERSION'
 tag-template: 'v$RESOLVED_VERSION'
-prerelease: true
-prerelease-identifier: 'alpha'
 
 template: |
   ## What's Changed

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,9 +1,12 @@
 name: Release Drafter
 
 on:
-  push:
-    branches:
-      - main
+  workflow_dispatch:
+    inputs:
+      prerelease-identifier:
+        description: 'alpha, beta, rc, etc'
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -16,5 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: release-drafter/release-drafter@v6
+        with:
+          prerelease-identifier: ${{ inputs.prerelease-identifier }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Revised the release drafter configuration to remove prerelease defaults and added a workflow_dispatch event. This change includes an optional input for prerelease identifiers, allowing manual specification during dispatch. Updated the workflow to handle this input dynamically.