### PR TITLE
Add named context disabling for query filters and interceptors

### DIFF
--- a/src/Core/Configurations/Builders/DocumentSetConfigurationBuilder.cs
+++ b/src/Core/Configurations/Builders/DocumentSetConfigurationBuilder.cs
@@ -18,12 +18,22 @@ public sealed class DocumentSetConfigurationBuilder<TDocument> : DocumentSetConf
 
     public void AddQueryFilter(Expression<Func<TDocument, bool>> expression)
     {
-        AddQueryFilter(new StaticQueryFilterDefinition<TDocument>(expression));
+        AddQueryFilter(null, expression);
+    }
+    
+    public void AddQueryFilter(string? name, Expression<Func<TDocument, bool>> expression)
+    {
+        AddQueryFilter(new StaticQueryFilterDefinition<TDocument>(expression, name));
     }
 
     public void AddQueryFilter(Func<IServiceProvider, Expression<Func<TDocument, bool>>> expression)
     {
-        AddQueryFilter(new ServiceProviderQueryFilterDefinition<TDocument>(expression));
+        AddQueryFilter(null, expression);
+    }
+    
+    public void AddQueryFilter(string? name, Func<IServiceProvider, Expression<Func<TDocument, bool>>> expression)
+    {
+        AddQueryFilter(new ServiceProviderQueryFilterDefinition<TDocument>(expression, name));
     }
 }
 
@@ -63,11 +73,21 @@ public class DocumentSetConfigurationBuilder
 
     public void AddQueryFilter(LambdaExpression expression)
     {
-        Builder.AddQueryFilter(expression);
+        AddQueryFilter(null, expression);
+    }
+    
+    public void AddQueryFilter(string? name, LambdaExpression expression)
+    {
+        Builder.AddQueryFilter(name, expression);
     }
 
     public void AddQueryFilter(Func<IServiceProvider, LambdaExpression> expressionProvider)
     {
-        Builder.AddQueryFilter(expressionProvider);
+        AddQueryFilter(null, expressionProvider);
+    }
+    
+    public void AddQueryFilter(string? name, Func<IServiceProvider, LambdaExpression> expressionProvider)
+    {
+        Builder.AddQueryFilter(name, expressionProvider);
     }
 }

--- a/src/Core/Configurations/Builders/InternalDocumentSetConfigurationBuilder.cs
+++ b/src/Core/Configurations/Builders/InternalDocumentSetConfigurationBuilder.cs
@@ -50,14 +50,14 @@ internal sealed class InternalDocumentSetConfigurationBuilder
         _queryFilterDefinitions.Add(queryFilterDefinition);
     }
 
-    public void AddQueryFilter(LambdaExpression expression)
+    public void AddQueryFilter(string? name, LambdaExpression expression)
     {
-        _queryFilterDefinitions.Add(new StaticQueryFilterDefinition(expression));
+        _queryFilterDefinitions.Add(new StaticQueryFilterDefinition(expression, name));
     }
 
-    public void AddQueryFilter(Func<IServiceProvider, LambdaExpression> expressionProvider)
+    public void AddQueryFilter(string? name, Func<IServiceProvider, LambdaExpression> expressionProvider)
     {
-        _queryFilterDefinitions.Add(new ServiceProviderQueryFilterDefinition(expressionProvider));
+        _queryFilterDefinitions.Add(new ServiceProviderQueryFilterDefinition(expressionProvider, name));
     }
 
     internal DocumentSetConfiguration Build()

--- a/src/Core/Configurations/Builders/VaultConfigurationBuilder.cs
+++ b/src/Core/Configurations/Builders/VaultConfigurationBuilder.cs
@@ -50,12 +50,22 @@ public class VaultConfigurationBuilder
 
     public void AddInterceptor<TInterceptor>(params object[] args) where TInterceptor : VaultInterceptor
     {
-        _interceptors.Add(new ServiceVaultInterceptorProvider(typeof(TInterceptor), args));
+        AddInterceptor<TInterceptor>(null, args);
+    }
+    
+    public void AddInterceptor<TInterceptor>(string? name, params object[] args) where TInterceptor : VaultInterceptor
+    {
+        _interceptors.Add(new ServiceVaultInterceptorProvider(typeof(TInterceptor), name, args));
     }
 
     public void AddInterceptor(VaultInterceptor interceptor)
     {
-        _interceptors.Add(new StaticVaultInterceptorProvider(interceptor));
+        AddInterceptor(null, interceptor);
+    }
+    
+    public void AddInterceptor(string? name, VaultInterceptor interceptor)
+    {
+        _interceptors.Add(new StaticVaultInterceptorProvider(interceptor, name));
     }
 
     public void SetDatabase(IMongoDatabase database)
@@ -70,7 +80,7 @@ public class VaultConfigurationBuilder
 
         AddMultiQueryFilters<TInterface>(expression);
 
-        AddInterceptor(new SoftDeleteInterceptor<TInterface>(options));
+        AddInterceptor("soft-delete", new SoftDeleteInterceptor<TInterface>(options));
     }
 
     public void AddMultiTenancy<TInterface, TTenantId>(VaultMultiTenancyOptions<TInterface, TTenantId> options) where TTenantId : struct
@@ -91,7 +101,7 @@ public class VaultConfigurationBuilder
             );
         });
 
-        AddInterceptor(new MultiTenancyInterceptor<TInterface, TTenantId>(options));
+        AddInterceptor("multi-tenancy", new MultiTenancyInterceptor<TInterface, TTenantId>(options));
     }
 
     public void AddMultiQueryFilters<TInterface>(Expression<Func<TInterface, bool>> expression)

--- a/src/Core/Configurations/DocumentSetConfiguration.cs
+++ b/src/Core/Configurations/DocumentSetConfiguration.cs
@@ -17,11 +17,6 @@ internal sealed class DocumentSetConfiguration
     public string Name { get; }
     public IReadOnlyCollection<IQueryFilterDefinition> QueryFilterDefinitions { get; }
 
-    internal LambdaExpression[] BuildQueryFilters(IServiceProvider serviceProvider)
-    {
-        return QueryFilterDefinitions.Select(x => x.Get(serviceProvider)).ToArray();
-    }
-
     public Expression<Func<TDocument, object>> GetKeyExpression<TDocument>()
     {
         var key = KeyExpressionCache<TDocument>.Get(Key);

--- a/src/Core/Configurations/VaultConfigurationManager.cs
+++ b/src/Core/Configurations/VaultConfigurationManager.cs
@@ -4,7 +4,7 @@ public abstract class VaultConfigurationManager
 {
     internal abstract VaultConfiguration Configuration { get; }
 
-    internal abstract VaultInterceptor[] ResolveInterceptors();
+    internal abstract (string? Name, VaultInterceptor Interceptor)[] ResolveInterceptors();
 
     internal abstract IServiceProvider ServiceProvider { get; }
     
@@ -36,10 +36,10 @@ public class VaultConfigurationManager<TVault> : VaultConfigurationManager where
 
     internal override VaultConfiguration Configuration { get; }
 
-    internal override VaultInterceptor[] ResolveInterceptors()
+    internal override (string? Name, VaultInterceptor Interceptor)[] ResolveInterceptors()
     {
         return Configuration.Interceptors
-            .Select(interceptorDefinition => interceptorDefinition.GetInterceptor(ServiceProvider))
+            .Select(interceptorDefinition => (interceptorDefinition.Name, interceptorDefinition.GetInterceptor(ServiceProvider)))
             .ToArray();
     }
 }

--- a/src/Core/Interceptors/IVaultInterceptorProvider.cs
+++ b/src/Core/Interceptors/IVaultInterceptorProvider.cs
@@ -2,5 +2,7 @@ namespace MongoFlow;
 
 internal interface IVaultInterceptorProvider
 {
+    string? Name { get; }
+    
     VaultInterceptor GetInterceptor(IServiceProvider serviceProvider);
 }

--- a/src/Core/Interceptors/ServiceVaultInterceptorProvider.cs
+++ b/src/Core/Interceptors/ServiceVaultInterceptorProvider.cs
@@ -8,11 +8,15 @@ internal sealed class ServiceVaultInterceptorProvider : IVaultInterceptorProvide
     private readonly object[] _args;
 
     public ServiceVaultInterceptorProvider(Type type,
+        string? name,
         object[] args)
     {
         _type = type;
         _args = args;
+        Name = name;
     }
+
+    public string? Name { get; }
 
     public VaultInterceptor GetInterceptor(IServiceProvider serviceProvider)
     {

--- a/src/Core/Interceptors/StaticVaultInterceptorProvider.cs
+++ b/src/Core/Interceptors/StaticVaultInterceptorProvider.cs
@@ -4,10 +4,14 @@ internal sealed class StaticVaultInterceptorProvider : IVaultInterceptorProvider
 {
     private readonly VaultInterceptor _interceptor;
 
-    public StaticVaultInterceptorProvider(VaultInterceptor interceptor)
+    public StaticVaultInterceptorProvider(VaultInterceptor interceptor,
+        string? name)
     {
         _interceptor = interceptor;
+        Name = name;
     }
+
+    public string? Name { get; }
 
     public VaultInterceptor GetInterceptor(IServiceProvider serviceProvider)
     {

--- a/src/Core/MultiTenancy/MultiTenancyDocumentSetExtensions.cs
+++ b/src/Core/MultiTenancy/MultiTenancyDocumentSetExtensions.cs
@@ -1,0 +1,11 @@
+namespace MongoFlow;
+
+public static class MultiTenancyDocumentSetExtensions
+{
+    public static DocumentSet<T> DisableMultiTenancy<T>(this DocumentSet<T> documentSet)
+    {
+        return documentSet
+            .DisableQueryFilters("multi-tenancy")
+            .DisableInterceptors("multi-tenancy");
+    }
+}

--- a/src/Core/Operations/AddOperation.cs
+++ b/src/Core/Operations/AddOperation.cs
@@ -4,9 +4,11 @@ public sealed class AddOperation<TDocument> : VaultOperation
 {
     private readonly TDocument _document;
 
-    public AddOperation(TDocument document)
+    public AddOperation(TDocument document,
+        DisableContext interceptorDisableContext)
     {
         _document = document;
+        InterceptorDisableContext = interceptorDisableContext;
     }
 
     public override Type DocumentType => typeof(TDocument);
@@ -16,6 +18,8 @@ public sealed class AddOperation<TDocument> : VaultOperation
     public override object? OldDocument => null;
 
     public override OperationType OperationType => OperationType.Add;
+    
+    public override DisableContext InterceptorDisableContext { get; }
 
     internal override Task<int> ExecuteAsync(VaultOperationContext context,
         CancellationToken cancellationToken = default)

--- a/src/Core/Operations/AddRangeOperation.cs
+++ b/src/Core/Operations/AddRangeOperation.cs
@@ -4,12 +4,16 @@ public sealed class AddRangeOperation<TDocument> : AddRangeOperation
 {
     private readonly IEnumerable<TDocument> _documents;
 
-    public AddRangeOperation(IEnumerable<TDocument> documents)
+    public AddRangeOperation(IEnumerable<TDocument> documents,
+        DisableContext interceptorDisableContext)
     {
         _documents = documents;
+        InterceptorDisableContext = interceptorDisableContext;
     }
 
     public override Type DocumentType => typeof(TDocument);
+
+    public override DisableContext InterceptorDisableContext { get; }
 
     internal override Task<int> ExecuteAsync(VaultOperationContext context,
         CancellationToken cancellationToken = default)

--- a/src/Core/Operations/Base/VaultOperation.cs
+++ b/src/Core/Operations/Base/VaultOperation.cs
@@ -9,6 +9,8 @@ public abstract class VaultOperation
     public abstract object? OldDocument { get; }
 
     public abstract OperationType OperationType { get; }
+    
+    public abstract DisableContext InterceptorDisableContext { get; }
 
     internal abstract Task<int> ExecuteAsync(VaultOperationContext context,
         CancellationToken cancellationToken = default);

--- a/src/Core/Operations/DeleteOperation.cs
+++ b/src/Core/Operations/DeleteOperation.cs
@@ -8,10 +8,13 @@ public sealed class DeleteOperation<TDocument> : VaultOperation
     private readonly Expression<Func<TDocument, bool>> _filter;
     private TDocument? _document;
 
-    public DeleteOperation(Expression<Func<TDocument, bool>> filter, TDocument? document)
+    public DeleteOperation(Expression<Func<TDocument, bool>> filter, 
+        TDocument? document,
+        DisableContext interceptorDisableContext)
     {
         _filter = filter;
         _document = document;
+        InterceptorDisableContext = interceptorDisableContext;
     }
 
     public override Type DocumentType => typeof(TDocument);
@@ -21,6 +24,8 @@ public sealed class DeleteOperation<TDocument> : VaultOperation
     public override object? CurrentDocument => null;
 
     public override OperationType OperationType => OperationType.Delete;
+    
+    public override DisableContext InterceptorDisableContext { get; }
 
     internal override async Task<int> ExecuteAsync(VaultOperationContext context, CancellationToken cancellationToken = default)
     {
@@ -43,8 +48,8 @@ public sealed class DeleteOperation<TDocument> : VaultOperation
         operation = operationType switch
         {
             _ when _document is null => null,
-            OperationType.Add => new AddOperation<TDocument>(_document),
-            OperationType.Update => new ReplaceOperation<TDocument>(_filter, _document),
+            OperationType.Add => new AddOperation<TDocument>(_document, InterceptorDisableContext),
+            OperationType.Update => new ReplaceOperation<TDocument>(_filter, _document, InterceptorDisableContext),
             OperationType.Delete => this,
             _ => null
         };

--- a/src/Core/Operations/ReplaceOperation.cs
+++ b/src/Core/Operations/ReplaceOperation.cs
@@ -9,10 +9,13 @@ public sealed class ReplaceOperation<TDocument> : VaultOperation
     private readonly TDocument _document;
     private TDocument? _oldDocument;
 
-    public ReplaceOperation(Expression<Func<TDocument, bool>> filter, TDocument document)
+    public ReplaceOperation(Expression<Func<TDocument, bool>> filter, 
+        TDocument document,
+        DisableContext interceptorDisableContext)
     {
         _filter = filter;
         _document = document;
+        InterceptorDisableContext = interceptorDisableContext;
     }
 
     public override Type DocumentType => typeof(TDocument);
@@ -22,6 +25,8 @@ public sealed class ReplaceOperation<TDocument> : VaultOperation
     public override object? OldDocument => _oldDocument;
 
     public override OperationType OperationType => OperationType.Update;
+    
+    public override DisableContext InterceptorDisableContext { get; }
 
     internal override async Task<int> ExecuteAsync(VaultOperationContext context, CancellationToken cancellationToken = default)
     {
@@ -46,8 +51,8 @@ public sealed class ReplaceOperation<TDocument> : VaultOperation
     {
         operation = operationType switch
         {
-            OperationType.Add => new AddOperation<TDocument>(_document),
-            OperationType.Delete => new DeleteOperation<TDocument>(_filter, _document),
+            OperationType.Add => new AddOperation<TDocument>(_document, InterceptorDisableContext),
+            OperationType.Delete => new DeleteOperation<TDocument>(_filter, _document, InterceptorDisableContext),
             _ => this
         };
 

--- a/src/Core/Operations/UpdateOperation.cs
+++ b/src/Core/Operations/UpdateOperation.cs
@@ -10,10 +10,13 @@ public class UpdateOperation<TDocument> : VaultOperation
     private TDocument? _currentDocument;
     private TDocument? _oldDocument;
 
-    public UpdateOperation(Expression<Func<TDocument, bool>> filter, UpdateDefinition<TDocument> update)
+    public UpdateOperation(Expression<Func<TDocument, bool>> filter, 
+        UpdateDefinition<TDocument> update,
+        DisableContext interceptorDisableContext)
     {
         _filter = filter;
         _update = update;
+        InterceptorDisableContext = interceptorDisableContext;
     }
 
     public override Type DocumentType => typeof(TDocument);
@@ -22,6 +25,8 @@ public class UpdateOperation<TDocument> : VaultOperation
     public override object? OldDocument => _oldDocument;
 
     public override OperationType OperationType => OperationType.Update;
+    
+    public override DisableContext InterceptorDisableContext { get; }
 
     internal override async Task<int> ExecuteAsync(VaultOperationContext context, CancellationToken cancellationToken = default)
     {
@@ -52,8 +57,8 @@ public class UpdateOperation<TDocument> : VaultOperation
     {
         operation = operationType switch
         {
-            OperationType.Add when _currentDocument is not null => new AddOperation<TDocument>(_currentDocument),
-            OperationType.Delete => new DeleteOperation<TDocument>(_filter, _currentDocument),
+            OperationType.Add when _currentDocument is not null => new AddOperation<TDocument>(_currentDocument, InterceptorDisableContext),
+            OperationType.Delete => new DeleteOperation<TDocument>(_filter, _currentDocument, InterceptorDisableContext),
             OperationType.Update => this,
             _ => null
         };

--- a/src/Core/QueryFilters/IQueryFilterDefinition.cs
+++ b/src/Core/QueryFilters/IQueryFilterDefinition.cs
@@ -4,6 +4,7 @@ namespace MongoFlow;
 
 public interface IQueryFilterDefinition
 {
+    string? Name { get; }
     LambdaExpression Get(IServiceProvider serviceProvider);
 }
 

--- a/src/Core/QueryFilters/ServiceProviderQueryFilterDefinition.cs
+++ b/src/Core/QueryFilters/ServiceProviderQueryFilterDefinition.cs
@@ -6,10 +6,14 @@ internal sealed class ServiceProviderQueryFilterDefinition : IQueryFilterDefinit
 {
     private readonly Func<IServiceProvider, LambdaExpression> _expressionProvider;
 
-    public ServiceProviderQueryFilterDefinition(Func<IServiceProvider, LambdaExpression> expressionProvider)
+    public ServiceProviderQueryFilterDefinition(Func<IServiceProvider, LambdaExpression> expressionProvider,
+        string? name)
     {
         _expressionProvider = expressionProvider;
+        Name = name;
     }
+
+    public string? Name { get; }
 
     public LambdaExpression Get(IServiceProvider serviceProvider)
     {
@@ -22,10 +26,14 @@ internal sealed class ServiceProviderQueryFilterDefinition<TDocument> : IQueryFi
 {
     private readonly Func<IServiceProvider, Expression<Func<TDocument, bool>>> _expressionProvider;
 
-    public ServiceProviderQueryFilterDefinition(Func<IServiceProvider, Expression<Func<TDocument, bool>>> expressionProvider)
+    public ServiceProviderQueryFilterDefinition(Func<IServiceProvider, Expression<Func<TDocument, bool>>> expressionProvider,
+        string? name)
     {
         _expressionProvider = expressionProvider;
+        Name = name;
     }
+
+    public string? Name { get; }
 
     public LambdaExpression Get(IServiceProvider serviceProvider)
     {

--- a/src/Core/QueryFilters/StaticQueryFilterDefinition.cs
+++ b/src/Core/QueryFilters/StaticQueryFilterDefinition.cs
@@ -6,10 +6,14 @@ internal sealed class StaticQueryFilterDefinition : IQueryFilterDefinition
 {
     private readonly LambdaExpression _expression;
 
-    public StaticQueryFilterDefinition(LambdaExpression expression)
+    public StaticQueryFilterDefinition(LambdaExpression expression,
+        string? name)
     {
+        Name = name;
         _expression = expression;
     }
+
+    public string? Name { get; }
 
     public LambdaExpression Get(IServiceProvider serviceProvider)
     {
@@ -21,10 +25,14 @@ internal sealed class StaticQueryFilterDefinition<TDocument> : IQueryFilterDefin
 {
     private readonly Expression<Func<TDocument, bool>> _expression;
 
-    public StaticQueryFilterDefinition(Expression<Func<TDocument, bool>> expression)
+    public StaticQueryFilterDefinition(Expression<Func<TDocument, bool>> expression,
+        string? name)
     {
+        Name = name;
         _expression = expression;
     }
+
+    public string? Name { get; }
 
     public LambdaExpression Get(IServiceProvider serviceProvider)
     {

--- a/src/Core/Set/DisableContext.cs
+++ b/src/Core/Set/DisableContext.cs
@@ -1,0 +1,25 @@
+namespace MongoFlow;
+
+public sealed class DisableContext
+{
+    private DisableContext(string[] disabledItems,
+        bool disableAll)
+    {
+        DisabledItems = disabledItems;
+        AllDisabled = disableAll;
+    }
+    
+    public string[] DisabledItems { get; }
+    public bool AllDisabled { get; }
+    
+    public static readonly DisableContext Empty = new([], false);
+    public static readonly DisableContext All = new([], true);
+    
+    public DisableContext Disable(string[] items)
+    {
+        if (AllDisabled) return this;
+        
+        var disabledItems = DisabledItems.Concat(items).Distinct().ToArray();
+        return new DisableContext(disabledItems, false);
+    }
+}

--- a/src/Core/SoftDelete/SoftDeleteDocumentSetExtensions.cs
+++ b/src/Core/SoftDelete/SoftDeleteDocumentSetExtensions.cs
@@ -1,0 +1,11 @@
+namespace MongoFlow;
+
+public static class SoftDeleteDocumentSetExtensions
+{
+    public static DocumentSet<T> DisableSoftDelete<T>(this DocumentSet<T> documentSet)
+    {
+        return documentSet
+            .DisableQueryFilters("soft-delete")
+            .DisableInterceptors("soft-delete");
+    }
+}


### PR DESCRIPTION
Introduce a system to disable specific or all query filters and interceptors using named contexts. This enhances flexibility in the `DocumentSet` configuration and allows for selectively toggling features without altering how operations are executed globally. The changes also include the addition of `Name` properties for better identification and management of filters and interceptors.