### PR TITLE
Add Properties to VaultConfigurationBuilder and update MongoDB.Driver

### DIFF
--- a/src/Core/Configurations/Builders/VaultConfigurationBuilder.cs
+++ b/src/Core/Configurations/Builders/VaultConfigurationBuilder.cs
@@ -20,6 +20,8 @@ public class VaultConfigurationBuilder
             _documentSetConfigurationBuilders[type] = new InternalDocumentSetConfigurationBuilder(documentSetProperty);
         }
     }
+    
+    public IEnumerable<VaultProperty> Properties => VaultPropertyCache.GetProperties(_vaultType).Values;
 
     public void ConfigureDocumentType<TDocument>(Action<DocumentSetConfigurationBuilder<TDocument>> configure)
     {

--- a/src/Core/MongoFlow.csproj
+++ b/src/Core/MongoFlow.csproj
@@ -19,7 +19,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.0" />
-    <PackageReference Include="MongoDB.Driver" Version="3.0.0" />
+    <PackageReference Include="MongoDB.Driver" Version="3.1.0" />
     <PackageReference Include="Semver" Version="3.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Expose Vault properties via a new `Properties` accessor in `VaultConfigurationBuilder` to enhance usability. Additionally, update the MongoDB.Driver package from version 3.0.0 to 3.1.0 for improved compatibility and bug fixes.